### PR TITLE
less limiting exports

### DIFF
--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ChemicalFilter.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ChemicalFilter.java
@@ -125,7 +125,7 @@ public class ChemicalFilter extends GenericFilter<ChemicalStack> {
         return newFilter;
     }
 
-    public ChemicalFilter copyWithAmount(int amount) {
+    public ChemicalFilter copyWithAmount(long amount) {
         ChemicalFilter newFilter = this.copy();
         newFilter.amount = amount;
         return newFilter;

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ChemicalUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ChemicalUtil.java
@@ -17,7 +17,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ChemicalUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/ChemicalUtil.java
@@ -17,6 +17,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,20 +40,53 @@ public class ChemicalUtil {
 
         // The logic changes with storage systems since these systems do not have slots
         if (inventoryFrom instanceof IStorageSystemChemicalHandler storageFrom) {
-            ChemicalStack extracted = storageFrom.extractChemical(filter, Action.SIMULATE);
-            ChemicalStack remaining = toSlot < 0
-                ? inventoryTo.insertChemical(extracted, Action.EXECUTE)
-                : inventoryTo.insertChemical(toSlot, extracted, Action.EXECUTE);
-            long inserted = extracted.getAmount() - remaining.getAmount();
-            if (inserted == 0) {
+            if (toSlot >= inventoryTo.getChemicalTanks()) {
                 return 0;
             }
-            needs -= inserted;
-            extracted.setAmount(inserted);
-            storageFrom.extractChemical(ChemicalFilter.fromStack(extracted), Action.EXECUTE);
+            int[] toSlots = (
+                toSlot >= 0
+                    ? IntStream.of(toSlot)
+                    : IntStream.range(0, inventoryTo.getChemicalTanks())
+            )
+                .filter((i)
+                    -> inventoryTo.getChemicalInTank(i).isEmpty()
+                    || filter.test(inventoryTo.getChemicalInTank(i))
+                )
+                .toArray();
+            if (toSlots.length == 0) {
+                return 0;
+            }
+
+            for (int i : toSlots) {
+                ChemicalStack stack = inventoryTo.getChemicalInTank(i);
+                ChemicalStack extracted = storageFrom.extractChemical(
+                    (stack.isEmpty() ? filter : ChemicalFilter.fromStack(stack))
+                        .copyWithAmount(needs),
+                    Action.SIMULATE
+                );
+                if (extracted.isEmpty()) {
+                    continue;
+                }
+                ChemicalStack remaining = toSlot < 0
+                    ? inventoryTo.insertChemical(extracted, Action.EXECUTE)
+                    : inventoryTo.insertChemical(toSlot, extracted, Action.EXECUTE);
+                long inserted = extracted.getAmount() - remaining.getAmount();
+                if (inserted == 0) {
+                    continue;
+                }
+                needs -= inserted;
+                extracted.setAmount(inserted);
+                storageFrom.extractChemical(ChemicalFilter.fromStack(extracted), Action.EXECUTE);
+                if (needs <= 0) {
+                    break;
+                }
+            }
             return filter.getAmount() - needs;
         }
 
+        if (fromSlot >= inventoryFrom.getChemicalTanks()) {
+            return 0;
+        }
         int[] fromSlots = (
             fromSlot >= 0
                 ? IntStream.of(fromSlot)
@@ -65,16 +99,30 @@ public class ChemicalUtil {
         }
 
         for (int i : fromSlots) {
-            ChemicalStack extracted = inventoryFrom.extractChemical(i, needs, Action.SIMULATE);
+            ChemicalStack stack = inventoryFrom.getChemicalInTank(i);
+            ChemicalStack extracted = fromSlot < 0
+                ? inventoryFrom.extractChemical(stack.copyWithAmount(needs), Action.SIMULATE)
+                : inventoryFrom.extractChemical(i, needs, Action.SIMULATE);
             if (extracted.isEmpty()) {
                 continue;
             }
-            ChemicalStack remaining = toSlot < 0
+            ChemicalStack remaining = toSlot < 0 && !(inventoryTo instanceof IStorageSystemChemicalHandler)
                 ? inventoryTo.insertChemical(extracted, Action.EXECUTE)
                 : inventoryTo.insertChemical(toSlot, extracted, Action.EXECUTE);
             long inserted = extracted.getAmount() - remaining.getAmount();
+            if (inserted == 0) {
+                continue;
+            }
             needs -= inserted;
-            inventoryFrom.extractChemical(i, inserted, Action.SIMULATE);
+            if (fromSlot < 0) {
+                extracted.setAmount(inserted);
+                inventoryFrom.extractChemical(extracted, Action.SIMULATE);
+            } else {
+                inventoryFrom.extractChemical(i, needs, Action.SIMULATE);
+            }
+            if (needs <= 0) {
+                break;
+            }
         }
         return filter.getAmount() - needs;
     }

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/FluidUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/FluidUtil.java
@@ -38,17 +38,27 @@ public class FluidUtil {
 
         // The logic changes with storage systems since these systems do not have slots
         if (inventoryFrom instanceof IStorageSystemFluidHandler storageFrom) {
-            FluidStack extracted = storageFrom.drain(filter, IFluidHandler.FluidAction.SIMULATE);
-            if (extracted.isEmpty()) {
-                return 0;
+            for (int i = 0; i < inventoryTo.getTanks() && needs >= 0; i++) {
+                FluidStack stack = inventoryTo.getFluidInTank(i);
+                if (!(stack.isEmpty() || filter.test(stack))) {
+                    continue;
+                }
+                FluidStack extracted = storageFrom.drain(
+                    (stack.isEmpty() ? filter : FluidFilter.fromStack(stack))
+                        .copyWithAmount(needs),
+                    IFluidHandler.FluidAction.SIMULATE
+                );
+                if (extracted.isEmpty()) {
+                    continue;
+                }
+                int inserted = inventoryTo.fill(extracted, IFluidHandler.FluidAction.EXECUTE);
+                if (inserted == 0) {
+                    continue;
+                }
+                needs -= inserted;
+                extracted.setAmount(inserted);
+                storageFrom.drain(FluidFilter.fromStack(extracted), IFluidHandler.FluidAction.EXECUTE);
             }
-            int inserted = inventoryTo.fill(extracted, IFluidHandler.FluidAction.EXECUTE);
-            if (inserted == 0) {
-                return 0;
-            }
-            needs -= inserted;
-            extracted.setAmount(inserted);
-            storageFrom.drain(FluidFilter.fromStack(extracted), IFluidHandler.FluidAction.EXECUTE);
             return filter.getAmount() - needs;
         }
 
@@ -62,6 +72,9 @@ public class FluidUtil {
                 continue;
             }
             int inserted = inventoryTo.fill(extracted, IFluidHandler.FluidAction.EXECUTE);
+            if (inserted == 0) {
+                continue;
+            }
             needs -= inserted;
             extracted.setAmount(inserted);
             inventoryFrom.drain(extracted, IFluidHandler.FluidAction.EXECUTE);

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/InventoryUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/InventoryUtil.java
@@ -58,23 +58,48 @@ public class InventoryUtil {
 
         // The logic changes with storage systems since these systems do not have slots
         if (inventoryFrom instanceof IStorageSystemItemHandler storageFrom) {
-            ItemStack extracted = storageFrom.extractItem(filter, true);
-            if (extracted.isEmpty()) {
+            if (toSlot >= inventoryTo.getSlots()) {
                 return 0;
             }
-            ItemStack remaining = toSlot < 0
-                ? ItemHandlerHelper.insertItem(inventoryTo, extracted, false)
-                : inventoryTo.insertItem(toSlot, extracted, false);
-            int inserted = extracted.getCount() - remaining.getCount();
-            if (inserted == 0) {
+            int[] toSlots = (
+                toSlot >= 0
+                    ? IntStream.of(toSlot)
+                    : IntStream.range(0, inventoryTo.getSlots())
+            )
+                .filter((i)
+                    -> inventoryTo.getStackInSlot(i).isEmpty()
+                    || filter.test(inventoryTo.getStackInSlot(i))
+                )
+                .toArray();
+            if (toSlots.length == 0) {
                 return 0;
             }
-            needs -= inserted;
-            extracted.setCount(inserted);
-            storageFrom.extractItem(ItemFilter.fromStack(extracted), false);
+
+            for (int i : toSlots) {
+                ItemStack existing = inventoryTo.getStackInSlot(i);
+                ItemStack extracted = storageFrom.extractItem(
+                    (existing.isEmpty() ? filter : ItemFilter.fromStack(existing))
+                        .copyWithCount(needs),
+                    true
+                );
+                if (extracted.isEmpty()) {
+                    continue;
+                }
+                ItemStack remaining = inventoryTo.insertItem(i, extracted, false);
+                int inserted = extracted.getCount() - remaining.getCount();
+                needs -= inserted;
+                extracted.setCount(inserted);
+                storageFrom.extractItem(ItemFilter.fromStack(extracted), false);
+                if (needs <= 0) {
+                    break;
+                }
+            }
             return filter.getCount() - needs;
         }
 
+        if (fromSlot >= inventoryFrom.getSlots()) {
+            return 0;
+        }
         int[] fromSlots = (
             fromSlot >= 0
                 ? IntStream.of(fromSlot)
@@ -86,29 +111,12 @@ public class InventoryUtil {
             return 0;
         }
 
-        if (inventoryTo instanceof IStorageSystemItemHandler storageTo) {
-            for (int i : fromSlots) {
-                ItemStack extracted = inventoryFrom.extractItem(i, needs, true);
-                if (extracted.isEmpty()) {
-                    continue;
-                }
-                ItemStack remaining = storageTo.insertItem(toSlot, extracted, false);
-                int inserted = extracted.getCount() - remaining.getCount();
-                needs -= inserted;
-                inventoryFrom.extractItem(i, inserted, false);
-                if (needs <= 0) {
-                    break;
-                }
-            }
-            return filter.getCount() - needs;
-        }
-
         for (int i : fromSlots) {
             ItemStack extracted = inventoryFrom.extractItem(i, needs, true);
             if (extracted.isEmpty()) {
                 continue;
             }
-            ItemStack remaining = toSlot < 0
+            ItemStack remaining = toSlot < 0 && !(inventoryTo instanceof IStorageSystemItemHandler)
                 ? ItemHandlerHelper.insertItem(inventoryTo, extracted, false)
                 : inventoryTo.insertItem(toSlot, extracted, false);
             int inserted = extracted.getCount() - remaining.getCount();

--- a/src/main/java/de/srendi/advancedperipherals/common/util/inventory/InventoryUtil.java
+++ b/src/main/java/de/srendi/advancedperipherals/common/util/inventory/InventoryUtil.java
@@ -76,9 +76,9 @@ public class InventoryUtil {
             }
 
             for (int i : toSlots) {
-                ItemStack existing = inventoryTo.getStackInSlot(i);
+                ItemStack stack = inventoryTo.getStackInSlot(i);
                 ItemStack extracted = storageFrom.extractItem(
-                    (existing.isEmpty() ? filter : ItemFilter.fromStack(existing))
+                    (stack.isEmpty() ? filter : ItemFilter.fromStack(stack))
                         .copyWithCount(needs),
                     true
                 );
@@ -87,6 +87,9 @@ public class InventoryUtil {
                 }
                 ItemStack remaining = inventoryTo.insertItem(i, extracted, false);
                 int inserted = extracted.getCount() - remaining.getCount();
+                if (inserted == 0) {
+                    continue;
+                }
                 needs -= inserted;
                 extracted.setCount(inserted);
                 storageFrom.extractItem(ItemFilter.fromStack(extracted), false);
@@ -120,6 +123,9 @@ public class InventoryUtil {
                 ? ItemHandlerHelper.insertItem(inventoryTo, extracted, false)
                 : inventoryTo.insertItem(toSlot, extracted, false);
             int inserted = extracted.getCount() - remaining.getCount();
+            if (inserted == 0) {
+                continue;
+            }
             needs -= inserted;
             inventoryFrom.extractItem(i, inserted, false);
             if (needs <= 0) {


### PR DESCRIPTION
makes exporting from storage systems less limiting
makes chemical transfers use the handler's distribution implementation
combines second and third cases in item transfer code to one

fixes a few bugs:
wrong `insertChemical`  implementation being called when importing chemicals to storage systems
break condition missing when importing chemicals to storage systems
missing checks for `to/fromSlot` going over slot limit, possible indexoutofbounds exception
chemical filter `copyWithAmount` takes an int instead of long
various missing`extracted.isEmpty()` and `inserted == 0` checks